### PR TITLE
Add Support for C++ Projects (.vcxproj)

### DIFF
--- a/repo_scanner.py
+++ b/repo_scanner.py
@@ -81,7 +81,7 @@ def scan_repository(repo_url):
     matches_found = {}
 
     for item in tree:
-        if item["type"] == "blob" and (item["path"].endswith(".csproj") or item["path"].endswith(".vbproj")):
+        if item["type"] == "blob" and (item["path"].endswith(".csproj") or item["path"].endswith(".vbproj") or item["path"].endswith(".vcxproj")):
             try:
                 content = get_file_content(owner, repo, item["path"])
                 found = [s for s in TARGET_STRINGS if s in content]


### PR DESCRIPTION
# Description

This PR extends the GitHub Backdoor Scanner to include C++ projects by adding the ability to scan .vcxproj files in addition to .csproj and .vbproj files.

# Details

included .vcxproj files

```diff
- if item["type"] == "blob" and (item["path"].endswith(".csproj") or item["path"].endswith(".vbproj")):
+ if item["type"] == "blob" and (item["path"].endswith(".csproj") or item["path"].endswith(".vbproj") or item["path"].endswith(".vcxproj")):
```

# Testing

For example, this backdoored project the scanner doesn't detect when using the original version.

![image](https://github.com/user-attachments/assets/1ac7e498-8d70-4e83-a8af-458f2babf9ab)

but with a simple modification it will

![image](https://github.com/user-attachments/assets/032ffe80-2cdf-40f5-ac35-039011b41b6f)

